### PR TITLE
Minor updates to the longitudinal stream

### DIFF
--- a/long_fastsurfer.sh
+++ b/long_fastsurfer.sh
@@ -89,6 +89,39 @@ FLAGS:
 
 With the exception of --t1, --t2, --sid, --seg_only and --surf_only, all
 run_fastsurfer.sh options are supported, see 'run_fastsurfer.sh --help'.
+
+
+REFERENCES:
+
+If you use this for research publications, please cite:
+
+Henschel L, Conjeti S, Estrada S, Diers K, Fischl B, Reuter M, FastSurfer - A
+ fast and accurate deep learning based neuroimaging pipeline, NeuroImage 219
+ (2020), 117012. https://doi.org/10.1016/j.neuroimage.2020.117012
+
+Henschel L*, Kuegler D*, Reuter M. (*co-first). FastSurferVINN: Building
+ Resolution-Independence into Deep Learning Segmentation Methods - A Solution
+ for HighRes Brain MRI. NeuroImage 251 (2022), 118933. 
+ http://dx.doi.org/10.1016/j.neuroimage.2022.118933
+
+For cerebellum sub-segmentation:
+Faber J*, Kuegler D*, Bahrami E*, et al. (*co-first). CerebNet: A fast and
+ reliable deep-learning pipeline for detailed cerebellum sub-segmentation.
+ NeuroImage 264 (2022), 119703.
+ https://doi.org/10.1016/j.neuroimage.2022.119703
+
+For hypothalamus sub-segemntation:
+Estrada S, Kuegler D, Bahrami E, Xu P, Mousa D, Breteler MMB, Aziz NA, Reuter M.
+ FastSurfer-HypVINN: Automated sub-segmentation of the hypothalamus and adjacent
+ structures on high-resolutional brain MRI. Imaging Neuroscience 2023; 1 1–32.
+ https://doi.org/10.1162/imag_a_00034
+
+For longitudinal processing:
+Reuter M, Schmansky NJ, Rosas HD, Fischl B. Within-subject template estimation
+ for unbiased longitudinal image analysis, NeuroImage 61:4 (2012).
+ https://doi.org/10.1016/j.neuroimage.2012.02.084
+
+
 EOF
 }
 

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -241,17 +241,6 @@ Resource Options:
                             Default: "$python"
                             (-s: do no search for packages in home directory)
 
- Longitudinal Flags:
-  --base                  For longitudinal template (base) creation. Will switch
-                            off all segmentation modules except ASEGDKT and run a
-                            few steps differently in the surface module.
-  --long <baseid>         For longitudinal time point creation, pass the ID of
-                            the base (template) which needs to exist already in
-                            the same subjects_dir. For segmentation modules this
-                            is identical to regular processing, for surface
-                            module skip many steps and initialize from subject
-                            template.
-
  Dev Flags:
   --ignore_fs_version     Switch on to avoid check for FreeSurfer version.
                             Program will terminate if the supported version
@@ -272,6 +261,19 @@ Resource Options:
                             speeds up processing if you e.g. just need the
                             segmentation stats!
   --allow_root            Allow execution as root user.
+
+ Longitudinal Helper Flags (only to-be-used indirectly via long_fastsurfer.sh,
+                            non-expert users should use long_fastsurfers.sh):
+  --base                  (Expert Usage) Longitudinal template (base) creation.
+                            Only ASEGDKT in segmentation and differences in the
+                            surface module. Requires logitudinal preparation
+                            (long_prepare_template.sh).
+  --long <baseid>         (Expert Usage) Longitudinal time point creation.
+                            Requires the base (template) already exists in the
+                            same subjects_dir under the SID <baseid>.
+                            Processing is identical to the regular cross-sectional
+                            pipeline for segmentation, surface module skips
+                            many steps and initializes from subject template.
 
 
 REFERENCES:
@@ -743,17 +745,16 @@ fi
 if [[ "$long" == "1" ]] && [[ "$base" == "1" ]]
 then
   echo "ERROR: You specified both --long and --base. You need to setup and then run base template first,"
-  echo "before you can run any longitudinal time points."
+  echo "  before you can run any longitudinal time points."
   exit 1;
 fi
 
 if [[ "$base" == "1" ]]
 then
   if [ ! -f "$sd/$subject/base-tps.fastsurfer" ] ; then
-    echo "ERROR: $subject is either not found in SUBJECTS_DIR"
-    echo "or it is not a longitudinal template directory (base),"
-    echo "which needs to contain base-tps.fastsurfer file. Please ensure that"
-    echo "the base (template) has been created with long_prepare_template.sh."
+    echo "ERROR: $subject is either not found in \$SUBJECTS_DIR or it is not a longitudinal template"
+    echo "  directory (base), which needs to contain base-tps.fastsurfer file. Please ensure that"
+    echo "  the base (template) has been created with long_prepare_template.sh."
     exit 1
   fi
   if [[ -z "$t1" ]] ; then
@@ -766,16 +767,14 @@ fi
 if [[ "$long" == "1" ]]
 then
   if [ ! -f "$sd/$baseid/base-tps.fastsurfer" ] ; then
-    echo "ERROR: $baseid is either not found in SUBJECTS_DIR"
-    echo "or it is not a longitudinal template directory (base),"
-    echo "which needs to contain base-tps.fastsurfer file. Please ensure that"
-    echo "the base (template) has been created with long_prepare_template.sh."
+    echo "ERROR: $baseid is either not found in \$SUBJECTS_DIR or it is not a longitudinal template"
+    echo "  directory (base), which needs to contain base-tps.fastsurfer file. Please ensure that"
+    echo "  the base (template) has been created with long_prepare_template.sh."
     exit 1
   fi
   if ! grep -Fxq "$subject" "$sd/$baseid/base-tps.fastsurfer" ; then
-    echo "ERROR: $subject id not found in base-tps.fastsurfer."
-    echo "Please ensure that this time point was included during creation"
-    echo " of the base (template)."
+    echo "ERROR: $subject id not found in base-tps.fastsurfer. Please ensure that this time point"
+    echo "  was included during creation of the base (template)."
     exit 1
   fi
   if [[ -z "$t1" ]] ; then

--- a/run_fastsurfer.sh
+++ b/run_fastsurfer.sh
@@ -262,18 +262,23 @@ Resource Options:
                             segmentation stats!
   --allow_root            Allow execution as root user.
 
- Longitudinal Helper Flags (only to-be-used indirectly via long_fastsurfer.sh,
-                            non-expert users should use long_fastsurfers.sh):
-  --base                  (Expert Usage) Longitudinal template (base) creation.
+ Longitudinal Flags (non-expert users should use long_fastsurfers.sh for
+                     sequential processing of longitudinal data):
+  --base                  Longitudinal template (base) processing.
                             Only ASEGDKT in segmentation and differences in the
-                            surface module. Requires logitudinal preparation
-                            (long_prepare_template.sh).
-  --long <baseid>         (Expert Usage) Longitudinal time point creation.
+                            surface module. Requires longitudinal template
+                            preparation (recon-surf/long_prepare_template.sh) to
+                            be completed beforehand! No T2 can be passed. Also
+                            no T1 is explicitly passed, as it is taken from
+                            within the prepared template directory.
+  --long <baseid>         Longitudinal time point processing.
                             Requires the base (template) already exists in the
-                            same subjects_dir under the SID <baseid>.
+                            same SUBJECTS_DIR under the SID <baseid>.
                             Processing is identical to the regular cross-sectional
-                            pipeline for segmentation, surface module skips
+                            pipeline for segmentation. Surface module skips
                             many steps and initializes from subject template.
+                            No T2 can be passed. Also no T1 is explicitly passed,
+                            as it is taken from the prepared template directory.
 
 
 REFERENCES:
@@ -300,6 +305,11 @@ Estrada S, Kuegler D, Bahrami E, Xu P, Mousa D, Breteler MMB, Aziz NA, Reuter M.
  FastSurfer-HypVINN: Automated sub-segmentation of the hypothalamus and adjacent
  structures on high-resolutional brain MRI. Imaging Neuroscience 2023; 1 1–32.
  https://doi.org/10.1162/imag_a_00034
+
+For longitudinal processing:
+Reuter M, Schmansky NJ, Rosas HD, Fischl B. Within-subject template estimation
+ for unbiased longitudinal image analysis, NeuroImage 61:4 (2012).
+ https://doi.org/10.1016/j.neuroimage.2012.02.084
 
 EOF
 }


### PR DESCRIPTION
This PR introduces some minor updates to the longitudinal stream of FastSurfer (long_fastsurfer.sh and run_fastsurfer.sh).

long_fastsurfer.sh
- Add checks for unsupported run_fastsurfer.sh arguments: --t1, --t2, --sid, --seg_only, surf_only -> --t2 is not currently supported, because this would need adapted pre-processing and multiple images
- Consistent formatting of Error Messages
- Fix incorrect formatting of arrays (@ vs. *)

run_fastsurfer.sh
- Change help text for longitudinal flags (point to long_fastsurfer.sh). In most cases, these flags should not be used by regular users, who should use long_fastsurfer.sh instead.